### PR TITLE
cursor-shows-at-wrong-place-after-font-change

### DIFF
--- a/src-web/components/TemplateEditor/scss/template-editor.scss
+++ b/src-web/components/TemplateEditor/scss/template-editor.scss
@@ -175,7 +175,7 @@
     }
 
     .yamlEditorContainer {
-      // total offset common.scss -> "font-family: RedHatText" effect on yamlEditor
+      // overwrite common.scss -> "font-family: RedHatText" effect on yamlEditor
       html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
         font-family: monospace;
       }


### PR DESCRIPTION
Another way is using exclude logic in common.scss -> "font-family: RedHatText" rules, I think current one is more straightforward and will not mess common.scss.