### PR TITLE
Add box shadow

### DIFF
--- a/scss/secondary-header.scss
+++ b/scss/secondary-header.scss
@@ -121,6 +121,7 @@
     // top: $secondary-header-top;
     background-color: $color__white;
     padding: 0.75rem 5% 0;
+    box-shadow: 0 0.1875rem 0.5rem 0 rgba(0,0,0,0.05);
     // padding: 0.75rem 5% 0;
     &.special-layout {
       header {


### PR DESCRIPTION
Part of [#2935](https://github.com/open-cluster-management/backlog/issues/2935)

Make the box shadow displays when page is scrolled down.

<img width="1181" alt="Screen Shot 2020-06-24 at 10 41 08 PM" src="https://user-images.githubusercontent.com/55596988/85578934-72c92580-b608-11ea-9ca6-5144123bb479.png">
