### PR TITLE
Wait for 20s before kicking off the test

### DIFF
--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -22,5 +22,9 @@ export DISABLE_CANARY_TEST=${DISABLE_CANARY_TEST:-false}
 
 # show all envs
 printenv
+
+# sleep 20s so that new identity provider could be picked up by OCP
+sleep 20
+
 # run test
 npm run test:e2e-headless


### PR DESCRIPTION
Noticed that if it is a fresh cluster, it takes some time for new identity provider to show up and use