### PR TITLE
E2E tests for disabled "View details" link - 6135

### DIFF
--- a/src-web/tableDefinitions/utils.js
+++ b/src-web/tableDefinitions/utils.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import moment from 'moment'
 import _ from 'lodash'
 import config from '../../lib/shared/config'
+import { Tooltip } from '@patternfly/react-core'
 import {
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
@@ -115,16 +116,18 @@ export function buildTemplateDetailLink(item, locale) {
   const showDetailsLink = _.get(item, 'showDetailsLink', true)
   if (message && policyName && policyNamespace && cluster && templateName && apiVersion && kind) {
     const templateDetailURL = `/multicloud/policies/all/${policyNamespace}/${policyName}/template/${cluster}/${apiVersion}/${kind}/${templateName}`
-    return <div>
+    return <div className='policy-details-message'>
       <TruncateText text={message} maxCharacters={300} textEnd={' '} />
       {showDetailsLink ?
         <Link to={templateDetailURL}>
           {msgs.get('table.actions.view.details', locale)}
         </Link>
         :
-        <span className='link-disabled'>
-          {msgs.get('table.actions.view.details', locale)}
-        </span>
+        <Tooltip content={msgs.get('error.permission.disabled', locale)}>
+          <span className='link-disabled'>
+            {msgs.get('table.actions.view.details', locale)}
+          </span>
+        </Tooltip>
       }
     </div>
   }

--- a/tests/e2e/rbac.test.js
+++ b/tests/e2e/rbac.test.js
@@ -110,7 +110,7 @@ module.exports = {
     page.verifyCreatePage(permissions.clusterAdmin, createPage, createdPolicy, [namespaces[0]], false)
     commonPage.deletePolicy(createdPolicy)
     commonPage.clearSearchValue()
-    page.verifyPolicyPage(policyName, permissions.clusterAdmin)
+    page.verifyPolicyPage(policyName, permissions.clusterAdmin, true)
   },
 
   'GRC RBAC: Namespaced admin user': () => {
@@ -124,28 +124,28 @@ module.exports = {
     commonPage.clearSearchValue()
     // Verify view permissions for this user by filtering for the specific policy
     page.verifyAllPage(`${policyName}-${namespaces[1]}`, 1, permissions.view)
-    page.verifyPolicyPage(policyName, permissions.admin)
+    page.verifyPolicyPage(policyName, permissions.admin, true)
   },
 
   'GRC RBAC: Namespaced edit user': () => {
     loginPage.authenticate('e2e-edit-ns')
     page.verifyAllPage(policyName, 1, permissions.edit)
     page.verifyCreatePage(permissions.edit)
-    page.verifyPolicyPage(policyName, permissions.edit)
+    page.verifyPolicyPage(policyName, permissions.edit, true)
   },
 
   'GRC RBAC: Namespaced view user': () => {
     loginPage.authenticate('e2e-view-ns')
     page.verifyAllPage(policyName, 1, permissions.view)
     page.verifyCreatePage(permissions.view)
-    page.verifyPolicyPage(policyName, permissions.view)
+    page.verifyPolicyPage(policyName, permissions.view, true)
   },
 
   'GRC RBAC: Namespaced view user in a group': () => {
     loginPage.authenticate('e2e-group-ns')
     page.verifyAllPage(policyName, 1, permissions.view)
     page.verifyCreatePage(permissions.view)
-    page.verifyPolicyPage(policyName, permissions.view)
+    page.verifyPolicyPage(policyName, permissions.view, true)
   },
 
   'GRC RBAC: Clean up': () => {

--- a/tests/page-objects/RbacPage.js
+++ b/tests/page-objects/RbacPage.js
@@ -27,6 +27,11 @@ module.exports = {
     namespaceDropdownBox: '.creation-view-controls-container > div > div:nth-child(2) > div.bx--list-box > div.bx--list-box__menu > div',
     placementRuleEdit: 'div.page-content-container div.overview-content-second > div.overview-content-second-cell:nth-child(1) button.text-edit-button',
     placementBindingEdit: 'div.page-content-container div.overview-content-second > div.overview-content-second-cell:nth-child(2) button.text-edit-button',
+    statusTab: '#status-tab',
+    statusTable: '.pattern-fly-table',
+    statusDetailsLink: 'tr:first-child div.policy-details-message > *',
+    statusClusterToggle_templates: '#policy-status-templates',
+    statusClusterToggle_clusters: '#policy-status-clusters',
     yamlTab: '#yaml-tab',
     yamlEditor: '.monaco-editor',
     yamlEditButton: '#edit-button',
@@ -89,7 +94,7 @@ function verifyAllPage(name, nsNum, permissions) {
   this.click('@searchInput').clearValue('@searchInput')
 }
 
-function verifyPolicyPage(name, permissions) {
+function verifyPolicyPage(name, permissions, namespaced=false) {
   this.log(`verifyPolicyPage policy: ${name} permissions: ${{permissions}}`)
   // Filter for our RBAC policies
   this.waitForElementVisible('@searchInput')
@@ -108,6 +113,31 @@ function verifyPolicyPage(name, permissions) {
     checkTooltip(this, '@placementBindingEdit', disableMsg)
     this.expect.element('@placementRuleEdit').to.not.be.enabled
     checkTooltip(this, '@placementRuleEdit', disableMsg)
+  }
+  // Check Status tab
+  //
+  // Only clusterwide users will have access to cluster information, so we don't
+  // run these tests for namespaced users
+  if (!namespaced) {
+    this.click('@statusTab')
+    this.waitForElementPresent('@statusTable')
+    // The "View details" link should be disabled with a tooltip since it requires
+    // permissions to create a managedClusterView
+    this.click('@statusClusterToggle_clusters')
+    if (permissions.create) {
+      this.expect.element('@statusDetailsLink').to.have.property('href')
+    } else {
+      this.expect.element('@statusDetailsLink').to.not.have.property('href')
+      checkTooltip(this, '@statusDetailsLink', disableMsg)
+    }
+    this.click('@statusClusterToggle_templates')
+    this.waitForElementPresent('@statusTable')
+    if (permissions.create) {
+      this.expect.element('@statusDetailsLink').to.have.property('href')
+    } else {
+      this.expect.element('@statusDetailsLink').to.not.have.property('href')
+      checkTooltip(this, '@statusDetailsLink', disableMsg)
+    }
   }
   // Check YAML tab
   this.click('@yamlTab')


### PR DESCRIPTION
Addresses https://github.com/open-cluster-management/backlog/issues/6135
Builds from https://github.com/open-cluster-management/grc-ui/pull/271

- Adds disabled Tooltip for the disabled link
- Implements E2E tests for the link (but has to skip the test for namespaced users since they won't have access to these tables since they don't have access to the cluster namespaces)
![image](https://user-images.githubusercontent.com/19750917/95793098-d90aae80-0cb2-11eb-94a2-ea1fb79d3b36.png)
