### PR TITLE
increase the number of maxClusterRoleBindingUsers

### DIFF
--- a/tests/e2e/yaml/iam_policy/create_test_clusterrolebinding.yaml
+++ b/tests/e2e/yaml/iam_policy/create_test_clusterrolebinding.yaml
@@ -66,6 +66,36 @@ spec:
                   - name: e2e-user-10
                     apiGroup: rbac.authorization.k8s.io
                     kind: User
+                  - name: e2e-user-11
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-12
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-13
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-14
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-15
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-16
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-17
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-18
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-19
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: e2e-user-20
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/tests/e2e/yaml/iam_policy/create_test_iam_policy.yaml
+++ b/tests/e2e/yaml/iam_policy/create_test_iam_policy.yaml
@@ -26,7 +26,7 @@ spec:
             include: ["*"]
             exclude: ["kube-*", "openshift-*"]
           remediationAction: inform
-          maxClusterRoleBindingUsers: 9
+          maxClusterRoleBindingUsers: 18
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
```
status:
  compliant: NonCompliant
  details:
  - compliant: NonCompliant
    history:
    - eventName: default.policy-iampolicy-1605062813292.164654bdc34fb21b
      lastTimestamp: "2020-11-11T02:58:11Z"
      message: NonCompliant; Number of users with clusteradmin role is 6 above the
        specified limit
    templateMeta:
      creationTimestamp: null
      name: policy-iampolicy-test-1605062813292
```
local-cluster in canary is failing. seems more users with clusteradmin role were added by other squad tests.
https://github.com/open-cluster-management/backlog/issues/6974