### PR TITLE
Store configuration files in plain text in environment variable.

### DIFF
--- a/tests/cypress/config/index.js
+++ b/tests/cypress/config/index.js
@@ -3,8 +3,7 @@ const fs = require('fs')
 const jsYaml = require('js-yaml')
 
 exports.getConfig = (filepath) => {
-  let config
-  config = fs.readFileSync(filepath).toString()
+  const config = fs.readFileSync(filepath).toString()
   console.log(filepath)
   console.log(config)
 


### PR DESCRIPTION
Original approach is storing configuration as JSON text. This prevents us to access the original content in a configuration file. This change stores plain text in environment variable instead.
Previously available function getConfigObject() remains functional (though we could extend in with parameter stating the config file format).
In addition new function getConfigText() is added.
Caution, this change could break loading a configuration in case you are using the following approach. In such a case please use getConfigObject() instead.
```
JSON.parse(Cypress.env('TEST_CONFIG_DEMO'))
```