### PR TITLE
set width to ensure the element doesn't extend the screen

### DIFF
--- a/scss/module-grc-cards.scss
+++ b/scss/module-grc-cards.scss
@@ -45,6 +45,7 @@
     top: -1.9375rem;
     left: 9.5rem;
     height: 0;
+    width: 50%;
     
     .header-divider {
       height: 1.5rem;


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/6710
<img width="1556" alt="image" src="https://user-images.githubusercontent.com/16092291/102121574-2c63bf00-3e12-11eb-915f-d25b7ce67171.png">
