### PR TITLE
Grc first page performace issue

### DIFF
--- a/src-web/components/common/FormatTableData.js
+++ b/src-web/components/common/FormatTableData.js
@@ -40,6 +40,8 @@ export const formatPoliciesToClustersTableData = (policies) => {
           } else if (policyCompliantStatusOnCluster === 'noncompliant') {
             nonCompliantNum = 1
             nonCompliantPolicyName = _.get(policy, 'metadata.name', '-')
+          } else {
+            nonCompliantPolicyName = _.get(policy, 'metadata.name', '-')
           }
           const singlePolicyData = {
             nameSpace,
@@ -67,7 +69,7 @@ export const formatPoliciesToClustersTableData = (policies) => {
           nonCompliant.push(singlePolicyData.nonCompliantPolicyName)
         }
         totalCompliantNum += singlePolicyData.compliantNum
-        totalNonCompliantNum += singlePolicyData.nonCompliantPolicyName
+        totalNonCompliantNum += singlePolicyData.nonCompliantNum
         consoleURL = singlePolicyData.consoleURL
       })
       const singleClusterData = {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7715

Original formatPolicyClusterView overall complexity is O(n^3)[Facepalm]
Rewrite it to overall complexity is O(n^2) and keep the exact same logic as the original formatPolicyClusterView function.

Tested with raw 1K+ policies test data from @cdoan1, old formatPolicyClusterView takes 40-60 seconds and new function takes less than 2 seconds.

This is just a bug fixing,  performance benchmark is still under planning.