### PR TITLE
wait for the policy status for all servers

### DIFF
--- a/tests/cypress/tests/common/generic_policies_governance.js
+++ b/tests/cypress/tests/common/generic_policies_governance.js
@@ -51,7 +51,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     const violationsCounter = getViolationsCounter(clusterViolations)
 
     it(`Wait for policy ${policyName} status to become available`, () => {
-      cy.waitForPolicyStatus(policyName)
+      cy.waitForPolicyStatus(policyName, violationsCounter)
     })
 
     it(`Check enabled policy ${policyName}`, () => {


### PR DESCRIPTION
Pass violationsCounter as an argument to make sure we are waiting for the respective value to appear.

This is a partial fix (or rather workaround) for the issue reported in
https://github.com/open-cluster-management/grc-ui/issues/396