### PR TITLE
add new commands and checks to avoid race conditions

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -2,7 +2,7 @@
 import { getOpt } from '../scripts/utils'
 import 'cypress-wait-until'
 import { pageLoader } from '../views/common'
-import { isPolicyStatusAvailable, doTableSearch, clearTableSearch } from '../views/policy'
+import { isPolicyStatusAvailable, isClusterPolicyStatusAvailable, doTableSearch, clearTableSearch } from '../views/policy'
 
 Cypress.Commands.add('login', (OPTIONS_HUB_USER, OPTIONS_HUB_PASSWORD, OC_IDP) => {
   var user = process.env.SELENIUM_USER || OPTIONS_HUB_USER || Cypress.env('OPTIONS_HUB_USER')
@@ -153,6 +153,16 @@ Cypress.Commands.add('waitForPolicyStatus', (name, violationsCounter) => {
   doTableSearch(name)
   cy.waitUntil(() => isPolicyStatusAvailable(name, violationsCounter), {'interval': 2000, 'timeout':60000})
     .then(() => clearTableSearch())
+})
+
+// needs to be run on /multicloud/policies/all/{namespace}/{policy} page
+// see isClusterPolicyStatusAvailable()
+Cypress.Commands.add('waitForClusterPolicyStatus', (clusterViolations, clusterList=null) => {
+  cy.waitUntil(() => { return isClusterPolicyStatusAvailable(clusterViolations, clusterList) }, {'interval': 2000, 'timeout':60000})
+})
+
+Cypress.Commands.add('waitForPageContentLoad', () => {
+  pageLoader.shouldNotExist()
 })
 
 Cypress.Commands.add('CheckGrcMainPage', () => {

--- a/tests/cypress/tests/common/generic_policies_governance.js
+++ b/tests/cypress/tests/common/generic_policies_governance.js
@@ -74,7 +74,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     const violationsCounter = getViolationsCounter(clusterViolations)
 
     it(`Verify policy ${policyName} details at the detailed page`, () => {
-      cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`)
+      cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
       verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
     })
 
@@ -87,11 +87,12 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     })
 
     it(`Verify policy ${policyName} placement rule at the detailed page`, () => {
+      cy.waitForClusterPolicyStatus(clusterViolations)  // since it could happen that some clusters do not have the status yet
       verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
     })
 
     it(`Verify policy ${policyName} violations at the Status - Clusters page`, () => {
-      cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`)
+      cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`).waitForPageContentLoad()
       // verify all violations per cluster
       verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
     })
@@ -105,7 +106,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
     for (const clusterName of clusterList) {
       it(`Verify policy details & templates on cluster ${clusterName} detailed page`, () => {
-        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`)
+        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
         cy.goToPolicyClusterPage(policyName, confPolicies[policyName], clusterName)
         verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
         verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
@@ -121,7 +122,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     for (const policyName in confPolicies) {
 
       it(`Enforce policy ${policyName}`, () => {
-        cy.visit('/multicloud/policies/all')
+        cy.visit('/multicloud/policies/all').waitForPageContentLoad()
         actionPolicyActionInListing(policyName, 'Enforce')
       })
 
@@ -141,7 +142,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
       const violationsCounter = getViolationsCounter(clusterViolations)
 
       it(`Wait for policy ${policyName} status to become available`, () => {
-        cy.visit('/multicloud/policies/all')
+        cy.visit('/multicloud/policies/all').waitForPageContentLoad()
         cy.waitForPolicyStatus(policyName, violationsCounter)
       })
 
@@ -150,7 +151,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
       })
 
       it(`Verify policy ${policyName} details at the detailed page`, () => {
-        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`)
+        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
         verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
       })
 
@@ -163,11 +164,12 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
       })
 
       it(`Verify policy ${policyName} placement rule at the detailed page`, () => {
+        cy.waitForClusterPolicyStatus(clusterViolations)  // since it could happen that some clusters do not have the status yet
         verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
       })
 
       it(`Verify policy ${policyName} violations at the Status - Clusters page`, () => {
-        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`)
+        cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`).waitForPageContentLoad()
         // verify all violations per cluster
         verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
       })
@@ -181,7 +183,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
       for (const clusterName of clusterList) {
         it(`Verify policy details & templates on cluster ${clusterName} detailed page`, () => {
-          cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`)
+          cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
           cy.goToPolicyClusterPage(policyName, confPolicies[policyName], clusterName)
           verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
           verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
@@ -222,7 +224,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
         const url = `/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status/${clusterName}/templates/${templateName}/history`
 
         it(`Verify the History page for policy ${policyName} cluster ${clusterName} template ${templateName}`, () => {
-          cy.visit(url)
+          cy.visit(url).waitForPageContentLoad()
           verifyPolicyViolationDetailsInHistory(templateName, violations, confViolationPatterns)
         })
 
@@ -234,7 +236,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
   for (const policyName in confPolicies) {
     it(`Policy ${policyName} can be deleted in the policy listing`, () => {
       // we could use a different way how to return to this page
-      cy.visit('/multicloud/policies/all')
+      cy.visit('/multicloud/policies/all').waitForPageContentLoad()
       actionPolicyActionInListing(policyName, 'Remove')
     })
 


### PR DESCRIPTION
This adds new commands and checks to avoid some issues:
- `isClusterPolicyStatusAvailable()` function to check if all clusters do have the expected status already - this is necessary because the overall policy status is not sufficient. The policy can be non-compliant even despite some clusters are still under evaluation.
- `waitForClusterPolicyStatus()` - a new command using the above function to wait for cluster statuses
- `waitForPageContentLoad()` - new command waiting until content loader (progress bar/spinner) is gone so we won't start with page processing too early