### PR TITLE
Make search field wider - 8972

### DIFF
--- a/scss/pattern-fly-table.scss
+++ b/scss/pattern-fly-table.scss
@@ -4,7 +4,8 @@
   .pf-c-search-input {
     background-color: white;
     margin: 8px 0 8px 0;
-    width: 248px;
+    min-width: 248px;
+    width: 32%;
 
     .pf-c-button {
       padding: 0;


### PR DESCRIPTION
Addresses https://github.com/open-cluster-management/backlog/issues/8972

Widen the search field to 1/3 of the screen with a minimum of its current width. This fits with the [UX design](https://marvelapp.com/prototype/798h1aa/screen/72419844) and will affect three tables:

**Overview**:
![image](https://user-images.githubusercontent.com/19750917/106476272-e079e180-6474-11eb-8944-d6b874f73f65.png)

**Status History View**:
![image](https://user-images.githubusercontent.com/19750917/106476193-cb9d4e00-6474-11eb-83b5-75b99e068102.png)

**Template Status Details**:
![image](https://user-images.githubusercontent.com/19750917/106476252-dce65a80-6474-11eb-84a6-fc94a68791db.png)