### PR TITLE
transform multiple common functions to cypress commands

### DIFF
--- a/tests/cypress/common/tests.js
+++ b/tests/cypress/common/tests.js
@@ -1,14 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import {
-  createPolicyFromSelection, verifyPolicyInListing, verifyPolicyNotInListing,
-  actionPolicyActionInListing, verifyPolicyInPolicyDetails, getDefaultSubstitutionRules,
-  verifyPolicyInPolicyDetailsTemplates, verifyPlacementRuleInPolicyDetails, verifyPlacementBindingInPolicyDetails,
-  verifyViolationsInPolicyStatusClusters, verifyViolationsInPolicyStatusTemplates,
-  getViolationsPerPolicy, getViolationsCounter, verifyPolicyDetailsInCluster, verifyPolicyTemplatesInCluster,
-  verifyPolicyViolationDetailsInCluster, verifyPolicyViolationDetailsInHistory,
-  createPolicyFromYAML
-} from './views'
+import { getDefaultSubstitutionRules, getViolationsPerPolicy, getViolationsCounter } from './views'
 import { getConfigObject } from '../config'
 
 
@@ -24,11 +16,11 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
     it(`Create new policy ${policyName} using the form`, () => {
       cy.FromGRCToCreatePolicyPage()
-      createPolicyFromSelection(policyName, true, confPolicies[policyName])
+        .createPolicyFromSelection(policyName, true, confPolicies[policyName])
     })
 
     it(`Check that policy ${policyName} is present in the policy listing`, () => {
-      verifyPolicyInListing(policyName, confPolicies[policyName])
+      cy.verifyPolicyInListing(policyName, confPolicies[policyName])
     })
 
     it(`Wait for policy ${policyName} status to become available`, () => {
@@ -36,15 +28,15 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     })
 
     it(`Disable policy ${policyName}`, () => {
-      actionPolicyActionInListing(policyName, 'Disable')
+     cy.actionPolicyActionInListing(policyName, 'Disable')
     })
 
     it(`Check disabled policy ${policyName}`, () => {
-      verifyPolicyInListing(policyName, confPolicies[policyName], 'disabled')
+      cy.verifyPolicyInListing(policyName, confPolicies[policyName], 'disabled')
     })
 
     it(`Enable policy ${policyName}`, () => {
-      actionPolicyActionInListing(policyName, 'Enable')
+      cy.actionPolicyActionInListing(policyName, 'Enable')
     })
 
   }
@@ -61,7 +53,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     })
 
     it(`Check enabled policy ${policyName}`, () => {
-      verifyPolicyInListing(policyName, confPolicies[policyName], 'enabled', violationsCounter)
+      cy.verifyPolicyInListing(policyName, confPolicies[policyName], 'enabled', violationsCounter)
     })
 
   }
@@ -76,43 +68,43 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
     it(`Verify policy ${policyName} details at the detailed page`, () => {
       cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
-      verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
+        .verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
     })
 
     it(`Verify policy ${policyName} template details at the detailed page`, () => {
-      verifyPolicyInPolicyDetailsTemplates(policyName, confPolicies[policyName])
+      cy.verifyPolicyInPolicyDetailsTemplates(policyName, confPolicies[policyName])
     })
 
     it(`Verify policy ${policyName} placement binding details at the detailed page`, () => {
-      verifyPlacementBindingInPolicyDetails(policyName, confPolicies[policyName])
+      cy.verifyPlacementBindingInPolicyDetails(policyName, confPolicies[policyName])
     })
 
     it(`Verify policy ${policyName} placement rule at the detailed page`, () => {
       cy.waitForClusterPolicyStatus(clusterViolations)  // since it could happen that some clusters do not have the status yet
-      verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
+        .verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
     })
 
     it(`Verify policy ${policyName} violations at the Status - Clusters page`, () => {
       cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`).waitForPageContentLoad()
       // verify all violations per cluster
       cy.waitForClusterTemplateStatus(clusterViolations)
-      verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
+        .verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
     })
 
     it(`Verify policy ${policyName} violations at the Status - Templates page`, () => {
       // open the Templates tab - we should have a command for this
       cy.get('#policy-status-templates').click()
       // verify violations per template
-      verifyViolationsInPolicyStatusTemplates(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
+        .verifyViolationsInPolicyStatusTemplates(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
     })
 
     for (const clusterName of clusterList) {
       it(`Verify policy details & templates on cluster ${clusterName} detailed page`, () => {
         cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
         cy.goToPolicyClusterPage(policyName, confPolicies[policyName], clusterName)
-        verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
-        verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
-        verifyPolicyViolationDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
+          .verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
+          .verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
+          .verifyPolicyViolationDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
       })
     }
 
@@ -125,12 +117,12 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
       it(`Enforce policy ${policyName}`, () => {
         cy.visit('/multicloud/policies/all').waitForPageContentLoad()
-        actionPolicyActionInListing(policyName, 'Enforce')
+          .actionPolicyActionInListing(policyName, 'Enforce')
       })
 
       it(`Check that enforced policy ${policyName} is present in the policy listing`, () => {
         confPolicies[policyName]['enforce'] = true
-        verifyPolicyInListing(policyName, confPolicies[policyName])
+        cy.verifyPolicyInListing(policyName, confPolicies[policyName])
       })
 
     }
@@ -149,48 +141,48 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
       })
 
       it(`Check enabled policy ${policyName}`, () => {
-        verifyPolicyInListing(policyName, confPolicies[policyName], 'enabled', violationsCounter)
+        cy.verifyPolicyInListing(policyName, confPolicies[policyName], 'enabled', violationsCounter)
       })
 
       it(`Verify policy ${policyName} details at the detailed page`, () => {
         cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
-        verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
+          .verifyPolicyInPolicyDetails(policyName, confPolicies[policyName], 'enabled', violationsCounter)
       })
 
       it(`Verify policy ${policyName} template details at the detailed page`, () => {
-        verifyPolicyInPolicyDetailsTemplates(policyName, confPolicies[policyName])
+        cy.verifyPolicyInPolicyDetailsTemplates(policyName, confPolicies[policyName])
       })
 
       it(`Verify policy ${policyName} placement binding details at the detailed page`, () => {
-        verifyPlacementBindingInPolicyDetails(policyName, confPolicies[policyName])
+        cy.verifyPlacementBindingInPolicyDetails(policyName, confPolicies[policyName])
       })
 
       it(`Verify policy ${policyName} placement rule at the detailed page`, () => {
         cy.waitForClusterPolicyStatus(clusterViolations)  // since it could happen that some clusters do not have the status yet
-        verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
+          .verifyPlacementRuleInPolicyDetails(policyName, confPolicies[policyName], clusterViolations)
       })
 
       it(`Verify policy ${policyName} violations at the Status - Clusters page`, () => {
         cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}/status`).waitForPageContentLoad()
         // verify all violations per cluster
         cy.waitForClusterTemplateStatus(clusterViolations)
-        verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
+          .verifyViolationsInPolicyStatusClusters(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
       })
 
       it(`Verify policy ${policyName} violations at the Status - Templates page`, () => {
         // open the Templates tab - we should have a command for this
         cy.get('#policy-status-templates').click()
         // verify violations per template
-        verifyViolationsInPolicyStatusTemplates(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
+          .verifyViolationsInPolicyStatusTemplates(policyName, confPolicies[policyName], clusterViolations, confViolationPatterns)
       })
 
       for (const clusterName of clusterList) {
         it(`Verify policy details & templates on cluster ${clusterName} detailed page`, () => {
           cy.visit(`/multicloud/policies/all/${confPolicies[policyName]['namespace']}/${policyName}`).waitForPageContentLoad()
           cy.goToPolicyClusterPage(policyName, confPolicies[policyName], clusterName)
-          verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
-          verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
-          verifyPolicyViolationDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
+            .verifyPolicyDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
+            .verifyPolicyTemplatesInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations)
+            .verifyPolicyViolationDetailsInCluster(policyName, confPolicies[policyName], clusterName, clusterViolations, confViolationPatterns)
         })
       }
 
@@ -228,7 +220,7 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
 
         it(`Verify the History page for policy ${policyName} cluster ${clusterName} template ${templateName}`, () => {
           cy.visit(url).waitForPageContentLoad()
-          verifyPolicyViolationDetailsInHistory(templateName, violations, confViolationPatterns)
+            .verifyPolicyViolationDetailsInHistory(templateName, violations, confViolationPatterns)
         })
 
       }
@@ -240,11 +232,11 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     it(`Policy ${policyName} can be deleted in the policy listing`, () => {
       // we could use a different way how to return to this page
       cy.visit('/multicloud/policies/all').waitForPageContentLoad()
-      actionPolicyActionInListing(policyName, 'Remove')
+        .actionPolicyActionInListing(policyName, 'Remove')
     })
 
     it(`Deleted policy ${policyName} is not present in the policy listing`, () => {
-      verifyPolicyNotInListing(policyName)
+      cy.verifyPolicyNotInListing(policyName)
     })
   }
 
@@ -262,11 +254,11 @@ export const test_applyPolicyYAML = (confFilePolicy, substitutionRules=null) => 
   it('Create the clean up policy using the YAML', () => {
     cy.visit('/multicloud/policies/create')
     cy.log(rawPolicyYAML)
-    createPolicyFromYAML(rawPolicyYAML, true)
+      .createPolicyFromYAML(rawPolicyYAML, true)
   })
 
   it(`Check that policy ${policyName} is present in the policy listing`, () => {
-    verifyPolicyInListing(policyName, {})
+    cy.verifyPolicyInListing(policyName, {})
   })
 
   it(`Wait for ${policyName} status to become available`, () => {
@@ -274,11 +266,11 @@ export const test_applyPolicyYAML = (confFilePolicy, substitutionRules=null) => 
   })
 
   it(`Delete policy ${policyName}`, () => {
-    actionPolicyActionInListing(policyName, 'Remove')
+    cy.actionPolicyActionInListing(policyName, 'Remove')
   })
 
   it(`Verify that policy ${policyName} is not present in the policy listing`, () => {
-    verifyPolicyNotInListing(policyName)
+    cy.verifyPolicyNotInListing(policyName)
   })
 
 }

--- a/tests/cypress/common/views.js
+++ b/tests/cypress/common/views.js
@@ -175,7 +175,7 @@ export const getDefaultSubstitutionRules = (rules = {}) => {
   return substitutions
 }
 
-export const createPolicyFromYAML = (policyYAML, create=true) => {
+export const action_createPolicyFromYAML = (policyYAML, create=true) => {
   console.log(policyYAML)
   cy.toggleYAMLeditor('On')
     .YAMLeditor()
@@ -190,7 +190,7 @@ export const createPolicyFromYAML = (policyYAML, create=true) => {
 }
 
 // this function is mainly used to testing selection on the create policy page
-export const createPolicyFromSelection = (uPolicyName, create=true, policyConfig) => {
+export const action_createPolicyFromSelection = (uPolicyName, create=true, policyConfig) => {
   // fill the form uName
   cy.get('input[aria-label="name"]')
     .clear()
@@ -249,7 +249,7 @@ export const createPolicyFromSelection = (uPolicyName, create=true, policyConfig
 // enabled='enabled', checking if policy is enabled; enabled='disabled', checking if policy is disabled
 // targetStatus = 0, don't check policy status; targetStatus = 1, check policy status is non-violation
 // targetStatus = 2, check policy status is violation; targetStatus = 3, check policy status is pending
-export const verifyPolicyInListing = (
+export const action_verifyPolicyInListing = (
   uName, policyConfig, enabled='enabled',
   violationsCounter='', targetStatus = null
   ) => {
@@ -328,7 +328,7 @@ export const verifyPolicyInListing = (
   clearTableSearch()
 }
 
-export const verifyPolicyNotInListing = (uName) => {
+export const action_verifyPolicyNotInListing = (uName) => {
   // either there are no policies at all or there are some policies listed
   if (!Cypress.$('#page').find('div.no-resource'.length)) {
     cy.get('.grc-view-by-policies-table').within(() => {
@@ -339,7 +339,7 @@ export const verifyPolicyNotInListing = (uName) => {
   }
 }
 
-export const actionPolicyActionInListing = (uName, action, cancel=false) => {
+export const action_actionPolicyActionInListing = (uName, action, cancel=false) => {
   cy.CheckGrcMainPage()
   doTableSearch(uName)
   cy.get('.grc-view-by-policies-table').within(() => {
@@ -511,7 +511,7 @@ export const isClusterTemplateStatusAvailable = (clusterViolations = {}) => {
   })
 }
 
-export const verifyPolicyInPolicyDetails = (
+export const action_verifyPolicyInPolicyDetails = (
   uName, policyConfig, enabled='enabled',
   violationsCounter='', targetStatus = null
   ) => {
@@ -601,7 +601,7 @@ const getStatusIconFillColor = (targetStatus) => {
 }
 
 
-export const verifyPlacementRuleInPolicyDetails = (policyName, policyConfig, clusterViolations, checkLength=true) => {
+export const action_verifyPlacementRuleInPolicyDetails = (policyName, policyConfig, clusterViolations, checkLength=true) => {
   cy.get('section[aria-label="Placement rule"]').within(() => {
     cy.get('.bx--structured-list-td').spread((
       label1, name, label2, namespace, label3,
@@ -834,7 +834,7 @@ export const getViolationsCounter = (clusterViolations) => {
   return violations+'/'+clusters
 }
 
-export const verifyPolicyInPolicyDetailsTemplates = (uName, policyConfig) => {
+export const action_verifyPolicyInPolicyDetailsTemplates = (uName, policyConfig) => {
   cy.get('#policy-templates-table-container').within(() => {
     const templates = getPolicyTemplatesNameAndKind(uName, policyConfig)
     for (const template of templates) {
@@ -851,7 +851,7 @@ export const verifyPolicyInPolicyDetailsTemplates = (uName, policyConfig) => {
   })
 }
 
-export const verifyPlacementBindingInPolicyDetails = (uName, policyConfig) => {
+export const action_verifyPlacementBindingInPolicyDetails = (uName, policyConfig) => {
   cy.get('section[aria-label="Placement binding"]').within(() => {
     cy.get('.bx--structured-list-td').spread((
       label1, name, label2, namespace, label3,
@@ -898,7 +898,7 @@ export const clearTableSearch = (inputSelector = null, parentSelector = null) =>
 }
 
 
-export const verifyViolationsInPolicyStatusClusters = (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
+export const action_verifyViolationsInPolicyStatusClusters = (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
   if (clusters == undefined) {
     clusters = Object.keys(clusterViolations)
   }
@@ -978,7 +978,7 @@ export const getPolicyStatusForViolationId = (id, format='long') => {
   }
 }
 
-export const verifyViolationsInPolicyStatusTemplates = (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
+export const action_verifyViolationsInPolicyStatusTemplates = (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
   if (clusters == undefined) {
     clusters = Object.keys(clusterViolations)
   }
@@ -1027,7 +1027,7 @@ export const verifyViolationsInPolicyStatusTemplates = (policyName, policyConfig
   }
 }
 
-export const verifyPolicyDetailsInCluster =  (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
+export const action_verifyPolicyDetailsInCluster =  (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
   const clusterStatus = getClusterPolicyStatus(clusterViolations[clusterName], 'short')
   cy.get('section[aria-label="Policy details"]').within(() => {
     cy.get('.bx--structured-list-td').spread((nameLabel, name, clusterLabel, cluster, messageLabel, message, statusLabel, status, enforcementLabel, enforcement ) => {
@@ -1062,7 +1062,7 @@ export const verifyPolicyDetailsInCluster =  (policyName, policyConfig, clusterN
   })
 }
 
-export const verifyPolicyTemplatesInCluster = (policyName, policyConfig, clusterName, clusterViolations) => {
+export const action_verifyPolicyTemplatesInCluster = (policyName, policyConfig, clusterName, clusterViolations) => {
   const violations = clusterViolations[clusterName]
   for (const violation of violations) {
     const templateName = violation.replace(/-[^-]*$/, '')
@@ -1092,7 +1092,7 @@ export const verifyPolicyTemplatesInCluster = (policyName, policyConfig, cluster
   }
 }
 
-export const verifyPolicyViolationDetailsInCluster = (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
+export const action_verifyPolicyViolationDetailsInCluster = (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
   const violations = clusterViolations[clusterName]
   for (const violation of violations) {
     const templateName = violation.replace(/-[^-]*$/, '')
@@ -1116,7 +1116,7 @@ export const verifyPolicyViolationDetailsInCluster = (policyName, policyConfig, 
   }
 }
 
-export const verifyPolicyViolationDetailsInHistory = (templateName, violations, violationPatterns) => {
+export const action_verifyPolicyViolationDetailsInHistory = (templateName, violations, violationPatterns) => {
   cy.get('table[aria-label="Sortable Table"]').within(() => {
     for (const violation of violations) {
       const id = violation.replace(/^.*-/, '')

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -2,7 +2,13 @@
 import { getOpt } from '../scripts/utils'
 import 'cypress-wait-until'
 import { pageLoader, isPolicyStatusAvailable, isClusterPolicyStatusAvailable, isClusterTemplateStatusAvailable,
-         doTableSearch, clearTableSearch
+         doTableSearch, clearTableSearch, action_createPolicyFromSelection, action_verifyPolicyInListing,
+         action_verifyPolicyNotInListing, action_actionPolicyActionInListing, action_createPolicyFromYAML,
+         action_verifyPolicyInPolicyDetails, action_verifyPolicyInPolicyDetailsTemplates,
+         action_verifyPlacementRuleInPolicyDetails, action_verifyPlacementBindingInPolicyDetails,
+         action_verifyViolationsInPolicyStatusClusters, action_verifyViolationsInPolicyStatusTemplates,
+         action_verifyPolicyDetailsInCluster, action_verifyPolicyTemplatesInCluster,
+         action_verifyPolicyViolationDetailsInCluster, action_verifyPolicyViolationDetailsInHistory
 } from '../common/views'
 
 Cypress.Commands.add('login', (OPTIONS_HUB_USER, OPTIONS_HUB_PASSWORD, OC_IDP) => {
@@ -169,7 +175,7 @@ Cypress.Commands.add('waitForClusterTemplateStatus', (clusterViolations = {}) =>
 })
 
 Cypress.Commands.add('waitForPageContentLoad', () => {
-  pageLoader.shouldNotExist()
+  cy.then(() => pageLoader.shouldNotExist())
 })
 
 Cypress.Commands.add('CheckGrcMainPage', () => {
@@ -206,4 +212,64 @@ Cypress.Commands.add('goToPolicyClusterPage', (policyName, policyConfig, cluster
   cy.get('.one-cluster-status').children('a').contains(clusterName).click()
   pageLoader.shouldNotExist()
   cy.location('pathname').should('eq', '/multicloud/policies/policy/'+clusterName+'/'+namespace+'.'+policyName)
+})
+
+Cypress.Commands.add('createPolicyFromSelection', (uPolicyName, create=true, policyConfig) => {
+  cy.then(() => action_createPolicyFromSelection(uPolicyName, create, policyConfig))
+})
+
+Cypress.Commands.add('verifyPolicyInListing', (uPolicyName, create, policyConfig) => {
+  cy.then(() => action_verifyPolicyInListing(uPolicyName, create, policyConfig))
+})
+
+Cypress.Commands.add('verifyPolicyNotInListing', (uPolicyName) => {
+  cy.then(() => action_verifyPolicyNotInListing(uPolicyName))
+})
+
+Cypress.Commands.add('actionPolicyActionInListing', (uName, action, cancel=false) => {
+  cy.then(() => action_actionPolicyActionInListing(uName, action, cancel))
+})
+
+Cypress.Commands.add('createPolicyFromYAML', (policyYAML, create=true) => {
+  cy.then(() => action_createPolicyFromYAML(policyYAML, create))
+})
+
+Cypress.Commands.add('verifyPolicyInPolicyDetails', (uName, policyConfig, enabled='enabled', violationsCounter='', targetStatus = null) => {
+  cy.then(() => action_verifyPolicyInPolicyDetails(uName, policyConfig, enabled, violationsCounter, targetStatus))
+})
+
+Cypress.Commands.add('verifyPolicyInPolicyDetailsTemplates', (uName, policyConfig) => {
+  cy.then(() => action_verifyPolicyInPolicyDetailsTemplates(uName, policyConfig))
+})
+
+Cypress.Commands.add('verifyPlacementRuleInPolicyDetails', (uName, policyConfig) => {
+  cy.then(() => action_verifyPlacementRuleInPolicyDetails(uName, policyConfig))
+})
+
+Cypress.Commands.add('verifyPlacementBindingInPolicyDetails', (uName, policyConfig) => {
+  cy.then(() => action_verifyPlacementBindingInPolicyDetails,(uName, policyConfig))
+})
+
+Cypress.Commands.add('verifyViolationsInPolicyStatusClusters', (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
+  cy.then(() => action_verifyViolationsInPolicyStatusClusters(policyName, policyConfig, clusterViolations, violationPatterns, clusters))
+
+})
+Cypress.Commands.add('verifyViolationsInPolicyStatusTemplates', (policyName, policyConfig, clusterViolations, violationPatterns, clusters = undefined) => {
+  cy.then(() => action_verifyViolationsInPolicyStatusTemplates,(policyName, policyConfig, clusterViolations, violationPatterns, clusters))
+})
+
+Cypress.Commands.add('verifyPolicyDetailsInCluster', (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
+  cy.then(() => action_verifyPolicyDetailsInCluster(policyName, policyConfig, clusterName, clusterViolations, violationPatterns))
+})
+
+Cypress.Commands.add('verifyPolicyTemplatesInCluster', (policyName, policyConfig, clusterName, clusterViolations) => {
+  cy.then(() => action_verifyPolicyTemplatesInCluster(policyName, policyConfig, clusterName, clusterViolations))
+})
+
+Cypress.Commands.add('verifyPolicyViolationDetailsInCluster', (policyName, policyConfig, clusterName, clusterViolations, violationPatterns) => {
+  cy.then(() => action_verifyPolicyViolationDetailsInCluster(policyName, policyConfig, clusterName, clusterViolations, violationPatterns))
+})
+
+Cypress.Commands.add('verifyPolicyViolationDetailsInHistory', (templateName, violations, violationPatterns) => {
+  cy.then(() => action_verifyPolicyViolationDetailsInHistory(templateName, violations, violationPatterns))
 })

--- a/tests/cypress/tests/CertPolicy_governance.spec.js
+++ b/tests/cypress/tests/CertPolicy_governance.spec.js
@@ -1,10 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import {
-  createPolicyFromYAML, verifyPolicyInListing, verifyPolicyNotInListing,
-  actionPolicyActionInListing, verifyPolicyInPolicyDetails, getDefaultSubstitutionRules,
-  verifyPolicyInPolicyStatus, verifyPolicyByYAML
-} from '../common/views'
+import { getDefaultSubstitutionRules, verifyPolicyInPolicyStatus, verifyPolicyByYAML } from '../common/views'
 import { test_applyPolicyYAML } from  '../common/tests'
 import { getUniqueResourceName } from '../scripts/utils'
 import { getConfigObject } from '../config'
@@ -45,7 +41,7 @@ describe('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
 
   it (`Create certificate policy ${uCertificatePolicyName}`, () => {
     cy.FromGRCToCreatePolicyPage()
-    createPolicyFromYAML(certificatePolicyYAML, true)
+      .createPolicyFromYAML(certificatePolicyYAML, true)
   })
 
   it(`Wait for certificate policy ${uCertificatePolicyName} status to become available`, () => {
@@ -54,15 +50,13 @@ describe('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
   })
 
   it (`Verify all information about the created certificate policy ${uCertificatePolicyName} on the "Govern and risk" page`, () => {
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+    cy.verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Validate violations/status of created policy ${uCertificatePolicyName} on the detailed policy page`, () => {
     // we need to find another way how to access this page
     cy.visit(`/multicloud/policies/all/default/${uCertificatePolicyName}`)
-      .then(() => {
-        verifyPolicyInPolicyDetails(uCertificatePolicyName, certificatePolicyConfig, 'enabled', '', 2)
-      })
+      .verifyPolicyInPolicyDetails(uCertificatePolicyName, certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Validate violations/status of created policy ${uCertificatePolicyName} on the policy status/history page`, () => {
@@ -82,43 +76,43 @@ describe('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
   it(`Validate disable of the policy ${uCertificatePolicyName}`, () => {
     // we could use a different way how to return to this page
     cy.visit('/multicloud/policies/all')
-    actionPolicyActionInListing(uCertificatePolicyName, 'Disable')
+      .actionPolicyActionInListing(uCertificatePolicyName, 'Disable')
   })
 
   it('Check disabled policy', () => {
     cy.CheckGrcMainPage()
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'disabled')
+      .verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'disabled')
   })
 
   it(`Validate enable of the policy ${uCertificatePolicyName}` , () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Enable')
-    cy.CheckGrcMainPage()
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Enable')
+      .CheckGrcMainPage()
   })
 
   it(`Check enabled policy ${uCertificatePolicyName}`, () => {
     cy.waitForPolicyStatus(uCertificatePolicyName)
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+      .verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Edit policy ${uCertificatePolicyName} and change "remediateAction" to "enforce"`, () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Enforce')
-    cy.CheckGrcMainPage()
-    cy.waitForPolicyStatus(uCertificatePolicyName)
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Enforce')
+      .CheckGrcMainPage()
+      .waitForPolicyStatus(uCertificatePolicyName)
   })
 
   it('Check violations stay reported but not remediated', () => {
     certificatePolicyConfig.enforce = true
     certificatePolicyConfig.inform = false
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+    cy.verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Remove created policy ${uCertificatePolicyName}`, () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Remove')
-    cy.CheckGrcMainPage()
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Remove')
+      .CheckGrcMainPage()
   })
 
   it(`Check created policy ${uCertificatePolicyName} is not present`, () => {
-    verifyPolicyNotInListing(uCertificatePolicyName)
+    cy.verifyPolicyNotInListing(uCertificatePolicyName)
   })
 })
 
@@ -132,7 +126,7 @@ describe('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
 
   it (`Create policy ${uCertificatePolicyName}`, () => {
     cy.FromGRCToCreatePolicyPage()
-    createPolicyFromYAML(certificatePolicyYAML, true)
+      .createPolicyFromYAML(certificatePolicyYAML, true)
   })
 
   it(`Certificate policy ${uCertificatePolicyName} status becomes available`, () => {
@@ -141,15 +135,13 @@ describe('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
   })
 
   it (`Verify all information about the created certificate policy ${uCertificatePolicyName} on the "Govern and risk" page`, () => {
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+    cy.verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Validate violations/status of created policy ${uCertificatePolicyName} on the detailed policy page`, () => {
     // we need to find another way how to access this page
     cy.visit(`/multicloud/policies/all/default/${uCertificatePolicyName}`)
-      .then(() => {
-        verifyPolicyInPolicyDetails(uCertificatePolicyName, certificatePolicyConfig, 'enabled', '', 2)
-      })
+      .verifyPolicyInPolicyDetails(uCertificatePolicyName, certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Validate violations/status of created policy ${uCertificatePolicyName} on the policy status/history page`, () => {
@@ -169,43 +161,43 @@ describe('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
   it(`Validate disable of the policy ${uCertificatePolicyName}`, () => {
     // we could use a different way how to return to this page
     cy.visit('/multicloud/policies/all')
-    actionPolicyActionInListing(uCertificatePolicyName, 'Disable')
+      .actionPolicyActionInListing(uCertificatePolicyName, 'Disable')
   })
 
   it('Check disabled policy', () => {
     cy.CheckGrcMainPage()
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'disabled')
+      .verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'disabled')
   })
 
   it(`Validate enable of the policy ${uCertificatePolicyName}` , () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Enable')
-    cy.CheckGrcMainPage()
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Enable')
+      .CheckGrcMainPage()
   })
 
   it(`Check enabled policy ${uCertificatePolicyName}`, () => {
     cy.waitForPolicyStatus(uCertificatePolicyName)
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+      .verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Edit policy ${uCertificatePolicyName} and change "remediateAction" to "enforce"`, () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Enforce')
-    cy.CheckGrcMainPage()
-    cy.waitForPolicyStatus(uCertificatePolicyName)
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Enforce')
+      .CheckGrcMainPage()
+      .waitForPolicyStatus(uCertificatePolicyName)
   })
 
   it('Check violations stay reported but not remediated', () => {
     certificatePolicyConfig.enforce = true
     certificatePolicyConfig.inform = false
-    verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
+    cy.verifyPolicyInListing(uCertificatePolicyName,  certificatePolicyConfig, 'enabled', '', 2)
   })
 
   it(`Remove created policy ${uCertificatePolicyName}`, () => {
-    actionPolicyActionInListing(uCertificatePolicyName, 'Remove')
-    cy.CheckGrcMainPage()
+    cy.actionPolicyActionInListing(uCertificatePolicyName, 'Remove')
+      .CheckGrcMainPage()
   })
 
   it(`Check created policy ${uCertificatePolicyName} is not present`, () => {
-    verifyPolicyNotInListing(uCertificatePolicyName)
+    cy.verifyPolicyNotInListing(uCertificatePolicyName)
   })
 })
 

--- a/tests/cypress/tests/InvalidYaml_governance.spec.js
+++ b/tests/cypress/tests/InvalidYaml_governance.spec.js
@@ -1,7 +1,7 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
 import { getConfigObject } from '../config'
-import { createPolicyFromYAML, getDefaultSubstitutionRules, checkNotificationMessage } from '../common/views'
+import { getDefaultSubstitutionRules, checkNotificationMessage } from '../common/views'
 const invalidYamlErrorMessages = getConfigObject('InvalidYamlTests/invalidYamlErrors.yaml', 'yaml')
 
 
@@ -10,24 +10,24 @@ describe('RHACM4K-247 - GRC UI: [P1][Sev1][policy-grc] Create policy with invali
     const confFilePolicy = 'InvalidYamlTests/InvalidPolicyName.yaml'
     const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', getDefaultSubstitutionRules())
     cy.visit('/multicloud/policies/create')
-    createPolicyFromYAML(rawPolicyYAML, false)
-    cy.get('#create-button-portal-id-btn').click()
+      .createPolicyFromYAML(rawPolicyYAML, false)
+      .get('#create-button-portal-id-btn').click()
     checkNotificationMessage('error', 'Create error:', invalidYamlErrorMessages['invalidName']['msg'])
   })
   it('Create policy should fail with missing namespace in yaml', () => {
     const confFilePolicy = 'InvalidYamlTests/MissingNamespace.yaml'
     const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', getDefaultSubstitutionRules())
     cy.visit('/multicloud/policies/create')
-    createPolicyFromYAML(rawPolicyYAML, false)
-    cy.get('#create-button-portal-id-btn').click()
+      .createPolicyFromYAML(rawPolicyYAML, false)
+      .get('#create-button-portal-id-btn').click()
     checkNotificationMessage('error', 'Create error:', invalidYamlErrorMessages['missingNamespace']['msg'])
   })
   it('Create policy should fail with invalid indentation in yaml', () => {
     const confFilePolicy = 'InvalidYamlTests/InvalidIndentation.yaml'
     const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', getDefaultSubstitutionRules())
     cy.visit('/multicloud/policies/create')
-    createPolicyFromYAML(rawPolicyYAML, false)
-    cy.get('#create-button-portal-id-btn').click()
+      .createPolicyFromYAML(rawPolicyYAML, false)
+      .get('#create-button-portal-id-btn').click()
     checkNotificationMessage('error', 'Create error:', invalidYamlErrorMessages['badIndentation']['msg'])
   })
 })

--- a/tests/cypress/tests/demos/policy-demo.spec.js
+++ b/tests/cypress/tests/demos/policy-demo.spec.js
@@ -1,11 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import {
-  createPolicyFromYAML, verifyPolicyInListing, verifyPolicyNotInListing,
-  actionPolicyActionInListing, getDefaultSubstitutionRules,
-  verifyPlacementRuleInPolicyDetails, verifyPlacementBindingInPolicyDetails,
-  verifyPolicyInPolicyDetails, verifyPolicyInPolicyDetailsTemplates
-} from '../../common/views'
+import { getDefaultSubstitutionRules } from '../../common/views'
 import { getUniqueResourceName } from '../../scripts/utils'
 import { getConfigObject } from '../../config'
 
@@ -22,11 +17,11 @@ describe('Testing policy named demo-policy in demo.yaml file', () => {
 
     it (`Can create new policy ${uPolicyName} from YAML editor`, () => {
       cy.FromGRCToCreatePolicyPage()
-      createPolicyFromYAML(policyYAML, true)
+        .createPolicyFromYAML(policyYAML, true)
     })
 
     it(`Policy ${uPolicyName} is present in the policy listing`, () => {
-      verifyPolicyInListing(uPolicyName,  policyConfig)
+      cy.verifyPolicyInListing(uPolicyName, policyConfig)
     })
 
     it('Policy status becomes available', () => {
@@ -37,59 +32,57 @@ describe('Testing policy named demo-policy in demo.yaml file', () => {
     })
 
     it('Disable policy', () => {
-      actionPolicyActionInListing(uPolicyName, 'Disable')
+      cy.actionPolicyActionInListing(uPolicyName, 'Disable')
     })
 
     it('Check disabled policy', () => {
-      verifyPolicyInListing(uPolicyName,  policyConfig, 'disabled')
+      cy.verifyPolicyInListing(uPolicyName, policyConfig, 'disabled')
     })
 
     it('Enable policy', () => {
-      actionPolicyActionInListing(uPolicyName, 'Enable')
+      cy.actionPolicyActionInListing(uPolicyName, 'Enable')
     })
 
     it('Check enabled policy', () => {
-      verifyPolicyInListing(uPolicyName,  policyConfig, 'enabled', '0/1')
+      cy.verifyPolicyInListing(uPolicyName, policyConfig, 'enabled', '0/1')
     })
 
     it('Enforce policy', () => {
-      actionPolicyActionInListing(uPolicyName, 'Enforce')
+      cy.actionPolicyActionInListing(uPolicyName, 'Enforce')
     })
 
     it('Check enforced policy', () => {
-       policyConfig.enforce = true
-       policyConfig.inform = false
-      verifyPolicyInListing(uPolicyName,  policyConfig)
+      policyConfig.enforce = true
+      policyConfig.inform = false
+      cy.verifyPolicyInListing(uPolicyName, policyConfig)
     })
 
     it('Inform policy', () => {
-      actionPolicyActionInListing(uPolicyName, 'Inform')
+      cy.actionPolicyActionInListing(uPolicyName, 'Inform')
     })
 
     it('Check informed policy', () => {
-       policyConfig.enforce = false
-       policyConfig.inform = true
-      verifyPolicyInListing(uPolicyName,  policyConfig)
+      policyConfig.enforce = false
+      policyConfig.inform = true
+      cy.verifyPolicyInListing(uPolicyName, policyConfig)
     })
 
     it('check policy and the detailed policy page', () => {
        // we need to find another way how to access this page
        cy.goToPolicyDetailsPage(uPolicyName, policyConfig['namespace'])
-         .then(() => {
-           verifyPolicyInPolicyDetails(uPolicyName, policyConfig, 'enabled', '0/1')
-           verifyPolicyInPolicyDetailsTemplates(uPolicyName, policyConfig)
-           verifyPlacementRuleInPolicyDetails(uPolicyName, policyConfig, confClusterViolations)
-           verifyPlacementBindingInPolicyDetails(uPolicyName, policyConfig)
-         })
+         .verifyPolicyInPolicyDetails(uPolicyName, policyConfig, 'enabled', '0/1')
+         .verifyPolicyInPolicyDetailsTemplates(uPolicyName, policyConfig)
+         .verifyPlacementRuleInPolicyDetails(uPolicyName, policyConfig, confClusterViolations)
+         .verifyPlacementBindingInPolicyDetails(uPolicyName, policyConfig)
     })
 
     it(`Policy ${uPolicyName} can be deleted in the policy listing`, () => {
       // we could use a different way how to return to this page
       cy.visit('/multicloud/policies/all')
-      actionPolicyActionInListing(uPolicyName, 'Remove')
+        .actionPolicyActionInListing(uPolicyName, 'Remove')
     })
 
     it(`Deleted policy ${uPolicyName} is not present in the policy listing`, () => {
-      verifyPolicyNotInListing(uPolicyName)
+      cy.verifyPolicyNotInListing(uPolicyName)
     })
 })

--- a/tests/cypress/tests/demos/violations-demo.spec.js
+++ b/tests/cypress/tests/demos/violations-demo.spec.js
@@ -1,8 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import {
-  getDefaultSubstitutionRules, verifyViolationsInPolicyStatusClusters, verifyViolationsInPolicyStatusTemplates
-} from '../../common/views'
+import { getDefaultSubstitutionRules } from '../../common/views'
 //import { getUniqueResourceName } from '../../scripts/utils'
 import { getConfigObject } from '../../config'
 
@@ -26,11 +24,11 @@ describe('Testing policy deviations as specified in the violations.yaml config f
     it ('All expected violations are listed', () => {
       cy.visit(`/multicloud/policies/all/default/${uPolicyName}/status`)
       // verify all violations per cluster
-      verifyViolationsInPolicyStatusClusters(uPolicyName, {'namespace': 'default'}, confClusterViolations, confViolationPatterns)
+        .verifyViolationsInPolicyStatusClusters(uPolicyName, {'namespace': 'default'}, confClusterViolations, confViolationPatterns)
       // open the Templates tab - we should have a command for this
       cy.get('#policy-status-templates').click()
       // verify violations per template
-      verifyViolationsInPolicyStatusTemplates(uPolicyName, {'namespace': 'default'}, confClusterViolations, confViolationPatterns)
+        .verifyViolationsInPolicyStatusTemplates(uPolicyName, {'namespace': 'default'}, confClusterViolations, confViolationPatterns)
     })
 
 })

--- a/tests/cypress/tests/issue2444_empty_namespace_list_in_configurationPolicy.spec.js
+++ b/tests/cypress/tests/issue2444_empty_namespace_list_in_configurationPolicy.spec.js
@@ -1,8 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import { createPolicyFromYAML, actionPolicyActionInListing, getDefaultSubstitutionRules,
-         verifyPolicyNotInListing, verifyViolationsInPolicyStatusClusters
-       } from '../common/views'
+import { getDefaultSubstitutionRules } from '../common/views'
 import { getConfigObject } from '../config'
 
 const confClusters = getConfigObject('clusters.yaml')
@@ -26,20 +24,20 @@ describe('RHACM4K-1650 - GRC UI: [P1][Sev1][policy-grc] configurationPoicy contr
   // create a Pod policy not matching any namespace in namespaceSelector
   it(`Create Pod policy ${policyName} from YAML, expecting a compliance`, () => {
     cy.FromGRCToCreatePolicyPage()
-      .then(() => { createPolicyFromYAML(rawPolicyYAML, true) } )
+      .createPolicyFromYAML(rawPolicyYAML, true)
       .CheckGrcMainPage()
       .waitForPolicyStatus(policyName)
   })
 
   it('Verify the violation is listed on a policy Status page', () => {
     cy.visit(`/multicloud/policies/all/default/${policyName}/status`).waitForPageContentLoad()
-    verifyViolationsInPolicyStatusClusters(policyName, policyConf, clusterViolations, confViolationPatterns)
+      .verifyViolationsInPolicyStatusClusters(policyName, policyConf, clusterViolations, confViolationPatterns)
   })
 
   it('Delete Pod policy ${policyName}', () => {
     cy.visit('/multicloud/policies/all')
-    actionPolicyActionInListing(policyName, 'Remove')
-    verifyPolicyNotInListing(policyName)
+      .actionPolicyActionInListing(policyName, 'Remove')
+      .verifyPolicyNotInListing(policyName)
   })
 
 })

--- a/tests/cypress/tests/issue3677_wrong_namespaceSelector.spec.js
+++ b/tests/cypress/tests/issue3677_wrong_namespaceSelector.spec.js
@@ -1,9 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import { createPolicyFromSelection, verifyPolicyInListing, actionPolicyActionInListing,
-         verifyPolicyNotInListing, getDefaultSubstitutionRules, verifyViolationsInPolicyStatusClusters,
-         getViolationsPerPolicy, getViolationsCounter
-       } from '../common/views'
+import { getDefaultSubstitutionRules, getViolationsPerPolicy, getViolationsCounter } from '../common/views'
 import { getConfigObject } from '../config'
 
 describe('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong namespace selector', () => {
@@ -25,7 +22,7 @@ describe('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong na
 
   it(`Prefill a new policy ${policyName} using the form`, () => {
     cy.FromGRCToCreatePolicyPage()
-    createPolicyFromSelection(policyName, false, confPolicy)
+      .createPolicyFromSelection(policyName, false, confPolicy)
   })
 
   it('Replace namespaceSelector value with "no-such-namespace"', () => {
@@ -48,7 +45,7 @@ describe('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong na
   })
 
   it(`Check that policy ${policyName} is present in the policy listing`, () => {
-    verifyPolicyInListing(policyName, confPolicy)
+    cy.verifyPolicyInListing(policyName, confPolicy)
   })
 
   it(`Wait for policy ${policyName} status to become available`, () => {
@@ -58,17 +55,17 @@ describe('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong na
   it(`Verify policy ${policyName} violations at the Status - Clusters page`, () => {
     cy.visit(`/multicloud/policies/all/${confPolicy['namespace']}/${policyName}/status`).waitForPageContentLoad()
     // verify all violations per cluster
-    verifyViolationsInPolicyStatusClusters(policyName, confPolicy, clusterViolations, confViolationPatterns)
+      .verifyViolationsInPolicyStatusClusters(policyName, confPolicy, clusterViolations, confViolationPatterns)
   })
 
   it(`Delete policy ${policyName}`, () => {
     // we could use a different way how to return to this page
     cy.visit('/multicloud/policies/all').waitForPageContentLoad()
-    actionPolicyActionInListing(policyName, 'Remove')
+      .actionPolicyActionInListing(policyName, 'Remove')
   })
 
   it(`Deleted policy ${policyName} is not present in the policy listing`, () => {
-    verifyPolicyNotInListing(policyName)
+    cy.verifyPolicyNotInListing(policyName)
   })
 
 })

--- a/tests/cypress/tests/issue7520_added_removed_namespaces.spec.js
+++ b/tests/cypress/tests/issue7520_added_removed_namespaces.spec.js
@@ -1,6 +1,6 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
-import { createPolicyFromYAML, actionPolicyActionInListing, getDefaultSubstitutionRules,
+import { getDefaultSubstitutionRules,
          verifyPolicyTemplateViolationDetailsForCluster
        } from '../common/views'
 import { test_applyPolicyYAML } from '../common/tests'
@@ -68,7 +68,7 @@ describe('RHACM4K-1691 - GRC UI: [P2][Sev2][policy-grc] Certificate policy contr
     const rawYAML = getConfigObject('issue7520/cert_policy_raw.yaml', 'raw', substitutionRules)
 
     cy.FromGRCToCreatePolicyPage()
-      .then(() => createPolicyFromYAML(rawYAML, true) )
+      .createPolicyFromYAML(rawYAML, true)
       .CheckGrcMainPage()
       .waitForPolicyStatus(certPolicyName, '0/1')
   })
@@ -162,7 +162,7 @@ describe('RHACM4K-1691 - GRC UI: [P2][Sev2][policy-grc] Certificate policy contr
   // delete cert policy
   it(`Remove cert policy ${certPolicyName}`, () => {
     cy.visit('/multicloud/policies/all')
-    actionPolicyActionInListing(certPolicyName, 'Remove')
+      .actionPolicyActionInListing(certPolicyName, 'Remove')
   })
 
   // delete namespace ns1


### PR DESCRIPTION
Multiple functions from common/views.js are transformed into a cypress command as proposed in 
https://github.com/open-cluster-management/grc-ui/issues/417#issuecomment-779800245

1. add `action_` prefix to an original function in `common/views.js`, e.g. `verifyPolicyInListing()` rename to `action_verifyPolicyInListing()`
2. introduce new command `cy.verifyPolicyInListing()` that would call `action_verifyPolicyInListing()`.
