### PR TITLE
Rebuild image

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,4 +188,3 @@ These are a few useful links that provide technical reference and best practices
 <!---
 Date: 01/17/2022
 -->
-


### PR DESCRIPTION
`grc-ui` no longer used in 2.5 and removed from pipeline in https://github.com/stolostron/pipeline/commit/f2c21a56ea075b72f080789f7e5fbc22b279db0d

No-op pr to resolve https://github.com/stolostron/backlog/issues/20740

Signed-off-by: Patrick Hickey <pahickey@redhat.com>