### PR TITLE
[release-2.4] Add `script-src: 'unsafe-eval'` to CSP

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -30,7 +30,7 @@ RUN npm install \
     cypress-wait-until \
     cypress-fail-fast \
     @cypress/code-coverage \
-    del \
+    del@6.1.1 \
     mocha \
     mocha-junit-reporter \
     mochawesome \

--- a/app.js
+++ b/app.js
@@ -53,6 +53,12 @@ app.use(helmet({ // in production these headers are set by management-ingress
   hsts: {
     maxAge:            63072000,
     preload:           true
+  },
+  contentSecurityPolicy: {
+    useDefaults: true,
+    directives: {
+      scriptSrc: ['\'self\'', '\'unsafe-eval\''],
+    }
   }
 }))
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6586,9 +6586,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001245",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-      "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA=="
+      "version": "1.0.30001400",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001400.tgz",
+      "integrity": "sha512-Mv659Hn65Z4LgZdJ7ge5JTVbE3rqbJaaXgW5LEI9/tOaXclfIZ8DW7D7FCWWWmWiiPS7AC48S8kf3DApSxQdgA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -16302,7 +16302,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "camelcase": {
@@ -19145,7 +19146,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "camelcase": {


### PR DESCRIPTION
Addresses:
- https://github.com/stolostron/backlog/issues/25785
- https://github.com/stolostron/backlog/issues/25708

The culprit is a `compile` call by Handlebars in the wizard. One solution is to precompile the template but since it's a wizard we need the YAML to dynamically be recompiled, so updating the CSP does seem to be the solution.

This PR matches a similar update in `console`:
- https://github.com/stolostron/console/pull/2034/files#diff-7c9509b8a3175758dd978aa69012afd03b1fa031c19880a3ebe877c47b38d56fR42

Other fields in the `console` PR match the defaults provided by `helmet`. (See `helmet.contentSecurityPolicy(options)` at https://helmetjs.github.io/). The resulting CSP after the change:
```yaml
Content-Security-Policy:
  script-src  'self' 'unsafe-eval';
  default-src 'self';
  base-uri  'self';
  block-all-mixed-content;
  font-src 'self' https:  data:;
  frame-ancestors 'self';
  img-src 'self' data:;
  object-src  'none';
  script-src-attr 'none';
  style-src 'self' https:  'unsafe-inline';
  upgrade-insecure-requests"
```

This also updates `caniuse-lite`, which is appearing in the logs and is a minor version update.